### PR TITLE
Fixes

### DIFF
--- a/web-extension/.vscode/settings.json
+++ b/web-extension/.vscode/settings.json
@@ -36,5 +36,22 @@
         "text",
         "yml"
     ],
-    "liveServer.settings.port": 5501
+    "liveServer.settings.port": 5501,
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#0089af",
+        "activityBar.activeBorder": "#ff9fea",
+        "activityBar.background": "#0089af",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#ff9fea",
+        "activityBarBadge.foreground": "#15202b",
+        "statusBar.background": "#00617c",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#0089af",
+        "titleBar.activeBackground": "#00617c",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#00617c99",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#00617C"
 }

--- a/web-extension/README.md
+++ b/web-extension/README.md
@@ -1,8 +1,49 @@
 # SP Formatter web extension
 
+This is the browser extension used in either [Google Chrome](https://developer.chrome.com/docs/extensions/) or the new [Microsoft Edge](https://developer.microsoft.com/microsoft-edge/extensions) (chromium).
+
 ## Development
 
-1. `npm i`
-2. `npm run watch`
-3. Create a new Chrome or Edge user profile. Go to extensions and enable Developer mode toggle.
-4. Load unpacked extension by selecting `<path to sp-formatter repository>/app` folder.
+To contribute to this extension, you'll need to setup your environment to be able to debug and validate your changes. This involves forking this repository, cloning it, creating a branch based on the `dev` branch, doing some awesome stuff, and then submitting a pull request. More details below!
+
+### Setting up your environment
+
+If you just want to build and run the extension locally you can clone the repository directly. BUT, if you'd like to contribute your changes back (yes, please!), you'll want to Fork the repository by clicking the Fork button in Github then clone that repository.
+
+Once cloned, open this folder (web-extension) in VSCode (or your preferred editor). You'll find all the source code in the `src` folder.
+
+But wait! There are a few tasks to get things setup. Fortunately, you'll only need to do them once and they should only take a few minutes:
+
+#### Install dependent packages
+
+Before you can do anything, you'll need to get the `node_modules` installed! You can do this from a terminal in this folder. We recommend opening a terminal directly in VSCode and then run the following command:
+
+`npm install`
+
+This will take a minute or two depending on your network speed. In the end, you'll have a new folder, `node_modules` that contains a few hundred megabytes worth of stuff that the extension and build system will use during development.
+
+#### Setup a development profile
+
+You'll need to configure your browser (Google Chrome or Microsoft Edge) to load the development version of the extension locally. Although you can do this in your primary profile, it is recommended to have a dedicated profile so that the development versions of extensions are isolated from your standard extensions.
+
+Use the following instructions to setup a new profile in either browser:
+
+- [Sign in and create multiple profiles in Microsoft Edge](https://support.microsoft.com/topic/sign-in-and-create-multiple-profiles-in-microsoft-edge-df94e622-2061-49ae-ad1d-6f0e43ce6435)
+- [Share Chrome with others](https://support.google.com/chrome/answer/2364824)
+
+#### Sideload the extension
+
+During develpment, the browser can run and debug the extensions safely by sideloading it from your local system. You just need to tell your browser about it!
+
+Use the following instructions to setup sideloading of the extension in your browser:
+
+- [Sideload an extension](https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/extension-sideloading) (Microsoft Edge)
+- [Getting started](https://developer.chrome.com/docs/extensions/mv3/getstarted/#manifest) (Google Chrome - skip the manifest part)
+
+Choose the `app` folder as the location of the extension.
+
+### Run the extension
+
+Now run the following command to build and run the extension:
+
+`npm run watch`

--- a/web-extension/package-lock.json
+++ b/web-extension/package-lock.json
@@ -70,107 +70,162 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-7.9.0.tgz",
-      "integrity": "sha512-D8p5WWeonqRO1EgIvo7WSlX1rcm87r2VQd62zTJPQImx8rpwc77CRI+iAvfxyVHRZMdt4Qk6Jq99dUaudPWaZw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.0.3.tgz",
+      "integrity": "sha512-dgiDSYctyKo56eNI7J3013KtOwVsNXvAFnDySVDkEp4BCQOZN9OVwp9kOgZRgoUGM1KOlDf8Ei2ThJsq6lmPXw==",
       "requires": {
-        "@uifabric/set-version": "^7.0.23",
+        "@fluentui/set-version": "^8.0.3",
         "tslib": "^1.10.0"
       }
     },
     "@fluentui/dom-utilities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-1.1.1.tgz",
-      "integrity": "sha512-w40gi8fzCpwa7U8cONiuu8rszPStkVOL/weDf5pCbYEb1gdaV7MDPSNkgM6IV0Kz+k017noDgK9Fv4ru1Dwz1g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.0.3.tgz",
+      "integrity": "sha512-RaUoEYd12TeEjvKLBtfXDZmjreaV6qIfBB7G+QCuBpv5FF7TjhrGK3WDZ7oaG0dkdegAx+ecyUFyOfoBRPJLkg==",
       "requires": {
-        "@uifabric/set-version": "^7.0.23",
+        "@fluentui/set-version": "^8.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@fluentui/font-icons-mdl2": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.0.5.tgz",
+      "integrity": "sha512-/2Qx/LCZH+rupbhzZ+WKCrw2XK3J2wj3pjMPLTLj/6rnmouA7yywFDiHIAseQXPhY34nzRVX4x3zEjz3RMWvmA==",
+      "requires": {
+        "@fluentui/set-version": "^8.0.3",
+        "@fluentui/style-utilities": "^8.0.5",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@fluentui/foundation-legacy": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.0.5.tgz",
+      "integrity": "sha512-bHODfopWfT4HfBvXFCyfKxi7/BrIVgKUvQ4X3L2GXUZv6jjQMvLPWZ1u8n2tdp91ch1KSWnBXklGaK/nyK1M5w==",
+      "requires": {
+        "@fluentui/merge-styles": "^8.0.4",
+        "@fluentui/set-version": "^8.0.3",
+        "@fluentui/style-utilities": "^8.0.5",
+        "@fluentui/utilities": "^8.0.5",
         "tslib": "^1.10.0"
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.12.tgz",
-      "integrity": "sha512-t3yIbbPKJubb22vQ/FIWwS9vFAzaPYzFxKWPHVWLtxs/P+5yL+LD3B16DRtYreWAdl9CZvEbos58ChLZ0KHwSQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.17.tgz",
+      "integrity": "sha512-iT1bU56rKrKEOfODoW6fScY11qj3iaYrZ+z11T6fo5+TDm84UGkkXjLXJTE57ZJzg0/gbccHQWYv+chY7bJN8Q==",
       "requires": {
         "tslib": "^1.10.0"
       }
     },
-    "@fluentui/react-compose": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-compose/-/react-compose-0.19.12.tgz",
-      "integrity": "sha512-GTcZ3kd2rTk3Q7xXJB8cTPfv0Q0vOdeIrLcJ02lXfjE9h3GPTE62rV4iFzBIZyXIKL8IdR6Jh8WNIBkVMWhhxw==",
+    "@fluentui/merge-styles": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.0.4.tgz",
+      "integrity": "sha512-2fd4u8u32hEdPGNBxTpUKQq5uUeMeJ0zigDjzAi6UCgnCZ+TkoC39LwJ/vFx77SMzd8YTNCh74vkzXiYZY38kA==",
       "requires": {
-        "@types/classnames": "^2.2.9",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/utilities": "^7.33.2",
-        "classnames": "^2.2.6",
+        "@fluentui/set-version": "^8.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@fluentui/react": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.12.0.tgz",
+      "integrity": "sha512-lkjK1KvJ3YR2t8ATDjf4Bdbq4snlgB6ZXFRUCaUPPBSiVep8LU754tXZDFfeIiyJEUgh+18og5yWMKuZSMdkkg==",
+      "requires": {
+        "@fluentui/date-time-utilities": "^8.0.3",
+        "@fluentui/font-icons-mdl2": "^8.0.5",
+        "@fluentui/foundation-legacy": "^8.0.5",
+        "@fluentui/merge-styles": "^8.0.4",
+        "@fluentui/react-focus": "^8.0.8",
+        "@fluentui/react-hooks": "^8.1.3",
+        "@fluentui/react-window-provider": "^2.0.3",
+        "@fluentui/set-version": "^8.0.3",
+        "@fluentui/style-utilities": "^8.0.5",
+        "@fluentui/theme": "^2.0.5",
+        "@fluentui/utilities": "^8.0.5",
+        "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^1.10.0"
       }
     },
     "@fluentui/react-focus": {
-      "version": "7.16.19",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.16.19.tgz",
-      "integrity": "sha512-BUnSJ7CRs0gfaEXVr5w9YQsZXB18J35k7H7eyB5wLLLgwdK/ogt6uYcu3p0q5ZEjju8C/wmJ2zgwFCMKiAyTUA==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.0.8.tgz",
+      "integrity": "sha512-fpeVvqe8Q9kSisla+/aFOGfT/NUqms/eICewTLbd/zTmGwqJ7Ayt8ibgg3oHo1Mh5yyGaK7ICLOrjlC4Z4tslQ==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.2.12",
-        "@fluentui/react-theme-provider": "^0.18.0",
-        "@uifabric/merge-styles": "^7.19.1",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/styling": "^7.16.18",
-        "@uifabric/utilities": "^7.33.2",
+        "@fluentui/keyboard-key": "^0.2.17",
+        "@fluentui/merge-styles": "^8.0.4",
+        "@fluentui/set-version": "^8.0.3",
+        "@fluentui/style-utilities": "^8.0.5",
+        "@fluentui/utilities": "^8.0.5",
         "tslib": "^1.10.0"
       }
     },
-    "@fluentui/react-stylesheets": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-stylesheets/-/react-stylesheets-0.2.4.tgz",
-      "integrity": "sha512-zTyDxBsQsm5iz59SXn83+BrC3tUnwQdJc/xcPYWWVISIyPby/75URbWK5uYJ5p5Qy0GrpgKDGYAbpXZlN89SRQ==",
+    "@fluentui/react-hooks": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.1.3.tgz",
+      "integrity": "sha512-6iWYjfqXvEhHZoY4nmN6APoIdxwNxzVxXOJgq1Oo1nbR10E7Va7mz41gvlFAgg8OmH7mGpdSztlVj6TVl/TY2g==",
       "requires": {
-        "@uifabric/set-version": "^7.0.23",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@fluentui/react-theme-provider": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-theme-provider/-/react-theme-provider-0.18.0.tgz",
-      "integrity": "sha512-dKSOZ1Sl2uVrDzjvfRtwHUluedU0MhEASukyeqGTpKTmg3ucPMYEZn+dgzFqRNpjs9trbb++N8R6Z19CWokXOw==",
-      "requires": {
-        "@fluentui/react-compose": "^0.19.12",
-        "@fluentui/react-stylesheets": "^0.2.4",
-        "@fluentui/react-window-provider": "^1.0.1",
-        "@fluentui/theme": "^1.7.0",
-        "@uifabric/merge-styles": "^7.19.1",
-        "@uifabric/react-hooks": "^7.13.9",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/utilities": "^7.33.2",
-        "classnames": "^2.2.6",
+        "@fluentui/react-window-provider": "^2.0.3",
+        "@fluentui/set-version": "^8.0.3",
+        "@fluentui/utilities": "^8.0.5",
         "tslib": "^1.10.0"
       }
     },
     "@fluentui/react-window-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.1.tgz",
-      "integrity": "sha512-5hvruDyF0uE8+6YN6Y+d2sEzexBadxUNxUjDcDreTPsmtHPwF5FPBYLhoD7T84L5U4YNvKxKh25tYJm6E0GE2w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.0.3.tgz",
+      "integrity": "sha512-eefkmzLJbYjVHtEtGbOwReyeYG+2bDefxdmvPRSVFlcRFCnasTvshuZj3xkaKSu5fsGzGw+f+ab3hDgLSETvbg==",
       "requires": {
-        "@uifabric/set-version": "^7.0.23",
+        "@fluentui/set-version": "^8.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@fluentui/set-version": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.0.3.tgz",
+      "integrity": "sha512-1Z7sWGnyqpNnmaauYIO+ra1gWA9Q68Y2juHa5goPn9ePLnzzLHZRZbYLSrXTjc9RrfCamq/S/2wPCJOn3N+Thw==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
+    "@fluentui/style-utilities": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.0.5.tgz",
+      "integrity": "sha512-UjOxYMnhiu4ClmC6y98rXRPvSHG9Bt7a2aNPvmSmTcrGCx8xskMndC45wiixdvGqwkuuBnJ6qinX/qpRjpBl7g==",
+      "requires": {
+        "@fluentui/merge-styles": "^8.0.4",
+        "@fluentui/set-version": "^8.0.3",
+        "@fluentui/theme": "^2.0.5",
+        "@fluentui/utilities": "^8.0.5",
+        "@microsoft/load-themed-styles": "^1.10.26",
         "tslib": "^1.10.0"
       }
     },
     "@fluentui/theme": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.0.tgz",
-      "integrity": "sha512-pzqDZC2bVD6/S45Bnve4wmrXi4cN7XiCr+OhzvgmoQfDkm5vyXsa82/cVtif/zy1OFU96S9zOTtt3e+QQuGUUg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.0.5.tgz",
+      "integrity": "sha512-1rN/YLguSVDHrqNvI5JcoDNna/ndT6i6GGXGhrDNPJvqLAh/rg0cnB3bytwOVMbdfBGP0LN73ox5v6dpO4krpA==",
       "requires": {
-        "@uifabric/merge-styles": "^7.19.1",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/utilities": "^7.33.2",
+        "@fluentui/merge-styles": "^8.0.4",
+        "@fluentui/set-version": "^8.0.3",
+        "@fluentui/utilities": "^8.0.5",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@fluentui/utilities": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.0.5.tgz",
+      "integrity": "sha512-epqvqV4YjKcbgShLhDk/y2Xa+6sUTBXry/BrMPNVwNOqdj2HCf4eCY+a1emFnytMpIVysfYZ6glIx9MNQ8JgNg==",
+      "requires": {
+        "@fluentui/dom-utilities": "^2.0.3",
+        "@fluentui/merge-styles": "^8.0.4",
+        "@fluentui/set-version": "^8.0.3",
         "tslib": "^1.10.0"
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.10.141",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.141.tgz",
-      "integrity": "sha512-IWqbTWhxpp10X2nZI14oqbPtzrRLvXtyX7sV/QDfVBtQQivLilZFynr/X69SAZtbSp/wi7WI8gKl2/6TuTNN1A=="
+      "version": "1.10.165",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.165.tgz",
+      "integrity": "sha512-3xMvFn1q27wctE701ZmdKDKgkj4b4DMHaJ8hnKk+c/E3Zvoo/5lviPZ0IGkD+zyfe7GMSp2kONalvX7Ez7HaKA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -207,11 +262,6 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
-    },
-    "@types/classnames": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
-      "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw=="
     },
     "@types/component-emitter": {
       "version": "1.2.10",
@@ -263,26 +313,32 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.14.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
-      "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
+      "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
       "requires": {
         "@types/prop-types": "*",
+        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "@types/react-dom": {
-      "version": "16.9.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
-      "integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.3.tgz",
+      "integrity": "sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==",
       "requires": {
-        "@types/react": "^16"
+        "@types/react": "*"
       }
     },
     "@types/resize-observer-browser": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.4.tgz",
       "integrity": "sha512-rPvqs+1hL/5hbES/0HTdUu4lvNmneiwKwccbWe7HGLWbnsLdqKnQHyWLg4Pj0AMO7PLHCwBM1Cs8orChdkDONg=="
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.10.0",
@@ -365,81 +421,6 @@
       "requires": {
         "@typescript-eslint/types": "4.10.0",
         "eslint-visitor-keys": "^2.0.0"
-      }
-    },
-    "@uifabric/foundation": {
-      "version": "7.9.20",
-      "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.20.tgz",
-      "integrity": "sha512-AcOClWfs+rNK0XyPLKTK2Nqeom7zOESOfL3Tbwl5VuDlSrlGW9yNywuuo6gJSOyXCJQO5dJFVdGExmB0EM4vkw==",
-      "requires": {
-        "@uifabric/merge-styles": "^7.19.1",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/styling": "^7.16.18",
-        "@uifabric/utilities": "^7.33.2",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/icons": {
-      "version": "7.5.17",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.17.tgz",
-      "integrity": "sha512-2S1kse0gtseTuV2r59iWukLxxoOJ6GgP2Yhxt9oxzaP9QubpYdxCUepvJmfPQQvvy4GELdykDUWQ6/hbzliJyw==",
-      "requires": {
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/styling": "^7.16.18",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/merge-styles": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.19.1.tgz",
-      "integrity": "sha512-yqUwmk62Kgu216QNPE9vOfS3h0kiSbTvoqM5QcZi+IzpqsBOlzZx3A9Er9UiDaqHRd5lsYF5pO/jeUULmBWF/A==",
-      "requires": {
-        "@uifabric/set-version": "^7.0.23",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/react-hooks": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.13.9.tgz",
-      "integrity": "sha512-VtDg2b3ypYXX7MLp1STk1Fj6ZIeZktXnm0hu1Os/pGvq6xkuLRly5XP6ZSHitm8K7ZcMo48CcNL8smmiXprBQg==",
-      "requires": {
-        "@fluentui/react-window-provider": "^1.0.1",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/utilities": "^7.33.2",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/set-version": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.23.tgz",
-      "integrity": "sha512-9E+YKtnH2kyMKnK9XZZsqyM8OCxEJIIfxtaThTlQpYOzrWAGJxQADFbZ7+Usi0U2xHnWNPFROjq+B9ocEzhqMA==",
-      "requires": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/styling": {
-      "version": "7.16.18",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.16.18.tgz",
-      "integrity": "sha512-jINFRMWfSIOZ4H29YNBHtwZU4f8JFprnyBX2E0Wq9rjqRzgcmdYbN2yn88gym6aC3houSDcYM0rdfG4ETjRQSA==",
-      "requires": {
-        "@fluentui/theme": "^1.7.0",
-        "@microsoft/load-themed-styles": "^1.10.26",
-        "@uifabric/merge-styles": "^7.19.1",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/utilities": "^7.33.2",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/utilities": {
-      "version": "7.33.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.33.2.tgz",
-      "integrity": "sha512-v2c3IUJdpru/hoGNOwIW549O5D4XBAc5sLpB7RREGI5ywoWuIJlNyYtBEGOwhAY62J2blj11qi86Ep+oZDM/Kw==",
-      "requires": {
-        "@fluentui/dom-utilities": "^1.1.1",
-        "@uifabric/merge-styles": "^7.19.1",
-        "@uifabric/set-version": "^7.0.23",
-        "prop-types": "^15.7.2",
-        "tslib": "^1.10.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -1588,11 +1569,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -2109,9 +2085,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -5510,26 +5486,6 @@
         "make-iterator": "^1.0.0"
       }
     },
-    "office-ui-fabric-react": {
-      "version": "7.155.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.155.0.tgz",
-      "integrity": "sha512-8ltreQbHqvE3zsuSK44W1o9TbsgYmbTFD+XFcL0h9maXsB9mlNi3yL4bFnphcvxiOHtpVztOaQTwwhIpsH+iyg==",
-      "requires": {
-        "@fluentui/date-time-utilities": "^7.9.0",
-        "@fluentui/react-focus": "^7.16.19",
-        "@fluentui/react-window-provider": "^1.0.1",
-        "@microsoft/load-themed-styles": "^1.10.26",
-        "@uifabric/foundation": "^7.9.20",
-        "@uifabric/icons": "^7.5.17",
-        "@uifabric/merge-styles": "^7.19.1",
-        "@uifabric/react-hooks": "^7.13.9",
-        "@uifabric/set-version": "^7.0.23",
-        "@uifabric/styling": "^7.16.18",
-        "@uifabric/utilities": "^7.33.2",
-        "prop-types": "^15.7.2",
-        "tslib": "^1.10.0"
-      }
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -5993,16 +5949,6 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -6129,30 +6075,23 @@
       }
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.2"
       }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -6442,9 +6381,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/web-extension/package.json
+++ b/web-extension/package.json
@@ -16,13 +16,13 @@
     "url": "https://github.com/pnp/sp-formatter"
   },
   "dependencies": {
-    "@types/react": "16.14.2",
-    "@types/react-dom": "16.9.10",
+    "@fluentui/react": "^8.12.0",
+    "@types/react": "^17.0.3",
+    "@types/react-dom": "^17.0.3",
     "@types/resize-observer-browser": "0.1.4",
-    "office-ui-fabric-react": "7.155.0",
     "pseudo-worker": "1.3.0",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "selector-observer": "2.1.6",
     "socket.io-client": "^3.0.4"
   },

--- a/web-extension/src/common/ExtensionStateManager.ts
+++ b/web-extension/src/common/ExtensionStateManager.ts
@@ -7,6 +7,11 @@ export class ExtensionStateManager {
   private static isEnbledKey = 'tab_enabled';
   private static extensionSettingsKey = 'extension_settings';
 
+  private static defaultSettings:IExtensionSettings = {
+    enhancedFormatterEnabled: false,
+    useDarkMode: false,
+  };
+
   public static async isEnabledForTab(tabId: number): Promise<boolean> {
     const result = await ChromeStorage.getItem<IExtensionTabEnabledData>(this.isEnbledKey);
     if (!result) {
@@ -30,7 +35,9 @@ export class ExtensionStateManager {
   public static async getExtensionSettings(): Promise<IExtensionSettings> {
     const result = await ChromeStorage.getItem<IExtensionSettings>(this.extensionSettingsKey);
     if (!result) {
-      return null;
+      //No settings found, so save and return defaults
+      await this.setExtensionSettings(this.defaultSettings);
+      return this.defaultSettings;
     }
     if (result.useDarkMode == null) {
       result.useDarkMode = false;

--- a/web-extension/src/common/PromiseTimeout.ts
+++ b/web-extension/src/common/PromiseTimeout.ts
@@ -1,18 +1,22 @@
+import {Logger} from './Logger'
+
 export function promiseTimeout(miliSeconds, promise, message): Promise<any> {
 
   return new Promise((resolve, reject) => {
 
     // create a timeout to reject promise if not resolved
     const timer = setTimeout(() => {
-      reject(new Error(message));
+      reject(new Error(message + ' timed out'));
     }, miliSeconds);
 
     promise
       .then((res) => {
+        Logger.log(message + ' resolved');
         clearTimeout(timer);
         resolve(res);
       })
       .catch((err) => {
+        Logger.log(message + ' errored');
         clearTimeout(timer);
         reject(err);
       });

--- a/web-extension/src/content/ContentManager.ts
+++ b/web-extension/src/content/ContentManager.ts
@@ -122,7 +122,7 @@ export class ContentManager {
       this.pagePipe.on<IPageContextInfo>(Content.onSendSpPageContextInfo, onRecievedCallback);
       this.pagePipe.emit(Content.onGetSpPageContextInfo, {});
     });
-    return promiseTimeout(this.schemaRequstTimeout, promise, 'getViewFormattingSchema');
+    return promiseTimeout(this.schemaRequstTimeout, promise, 'getSpPageContextInfo');
   }
 
   private async initInjectScripts(enable: boolean): Promise<void> {

--- a/web-extension/src/content/page/SpPageContextProvider.ts
+++ b/web-extension/src/content/page/SpPageContextProvider.ts
@@ -1,11 +1,12 @@
 import { Content } from '../../common/events/Events';
 import { WebEventEmitter } from '../../common/events/WebEventEmitter';
+import { IPageContextInfo } from '../../typings';
 
 const pagePipe = WebEventEmitter.instance;
 
 pagePipe.on(Content.onGetSpPageContextInfo, async () => {
   if (window._spPageContextInfo) {
-    pagePipe.emit(Content.onSendSpPageContextInfo, window._spPageContextInfo);
+    pagePipe.emit(Content.onSendSpPageContextInfo, {isSPO: window._spPageContextInfo.isSPO} as IPageContextInfo);
   } else if (window.moduleLoaderPromise) {
     const ctx = await window.moduleLoaderPromise;
     const legacyContext = ctx.context.pageContext.legacyPageContext;

--- a/web-extension/src/content/page/components/ColumnFormatterSettings.tsx
+++ b/web-extension/src/content/page/components/ColumnFormatterSettings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Toggle, IconButton, FontIcon } from 'office-ui-fabric-react/';
+import { Toggle, IconButton, FontIcon } from '@fluentui/react/';
 import { ContentService } from '../services/ContentService';
 import { WebEventEmitter } from '../../../common/events/WebEventEmitter';
 import { Content } from '../../../common/events/Events';

--- a/web-extension/src/content/page/legacy/Inject.ts
+++ b/web-extension/src/content/page/legacy/Inject.ts
@@ -5,8 +5,8 @@ import { ColumnFormatterSettings } from './../components/ColumnFormatterSettings
 import { enableFormatter } from './ColumnFormatterEnhancer';
 import { DomService, ViewType } from './../services/DomService';
 import { getListFields } from './../services/SPService';
-import { GlobalSettings } from '@uifabric/utilities/lib/GlobalSettings';
-import { getTheme } from '@uifabric/styling/lib/styles/theme';
+import { GlobalSettings } from '@fluentui/utilities/lib/GlobalSettings';
+import { getTheme } from '@fluentui/style-utilities/lib/styles/theme';
 
 // if SP 2019
 if (!window._spPageContextInfo.isSPO) {

--- a/web-extension/src/popup/Popup.tsx
+++ b/web-extension/src/popup/Popup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render } from 'react-dom';
-import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { Toggle } from '@fluentui/react/lib/Toggle';
 
 import { ExtensionStateManager } from '../common/ExtensionStateManager';
 import { ChromeEventEmitter } from '../common/events/ChromeEventEmitter';


### PR DESCRIPTION
I noticed SP Formatter was no longer working for me starting earlier this week. I've been meaning to dive further into your awesome code for a while so this was a nice excuse. I found a few issues that I corrected (details below), but the biggest issue was ultimately a relatively simple fix.

### Page Context Data Clone Error

![image](https://user-images.githubusercontent.com/8364109/116003836-e4c61e80-a5cd-11eb-9d0c-38c5a395944b.png)

The `onGetSPPageContextInfo` event was sending the entire `_spPageContextInfo`. With some new additions to the context, the `emit` function was failing because of how `postMessage` implements it's data clone. This error was killing the whole extension. To correct, I adjusted the response data in the `SPPageContextProvider` to only return the `isSPO` value from the context instead of the entire context. This will mean additional context info may need to be explicitly mapped but should prevent unexpected failures as Microsoft makes changes to the `_spPageContextInfo`.

I did NOT touch the `legacyContext`.

### Other Changes

These other changes are not critical to SP Formatter's functioning. So it's cool if you don't feel these are right for the extension and just want to implement the above fix and reject the rest.

#### Updated to @FluentUI/react 8 and react/react-dom 17

React 16 is affected by the SharedArrayBuffer changes and it is causing issues (warnings for now but potential failures soon) in the extension. This issue (within the Scheduler dependency in React) was corrected in 17.0.2.

![image](https://user-images.githubusercontent.com/8364109/116003868-17701700-a5ce-11eb-8036-04e203c0bb52.png)

I went ahead and moved the extension to react/react-dom to 17.0.2 and removed office-ui-fabric-react in favor of the new @fluentui/react 8.12.0.

I have run into zero issues with this change, but this is likely the most controversial item in this pull request so feel free to reject.

#### useDarkMode initial setting error

When extension settings are first returned, if there isn't yet settings stored the settings returned are null. This is fine for the `enhanceFormatterEnabled` setting as the default value for this is handled. Unfortunately, the `useDarkMode` setting is referenced before being set and this was throwing an error and making it impossible to toggle the setting. I added defaultSettings and when no settings are retrieved from storage these are used and the defaults saved.

#### Added more detail to the Web Extension README

Added additional notes and links for getting the development environment setup based on my experience.

#### Minor Junk

I added some more logging in the PromiseTimeout to help troubleshoot the issues with the page context. In doing so I found that the message used in the getSpPageContextInfo timeout initiated by the ContentManager was using the wrong label.
